### PR TITLE
Removed unneeded oUser constructor

### DIFF
--- a/src/oUsers.php
+++ b/src/oUsers.php
@@ -66,22 +66,6 @@ Class oUsers extends \obray\oDBO
         'blah' => 1
     );
 
-    public function __construct()
-    {
-
-        $dependencies = include "dependencies/config.php";
-        forEach ($dependencies as $key => $dependency) {
-            if ($key !== 'oUsers') {
-                $this->$key = $dependency;
-            }
-        }
-
-//        parent::__construct();
-
-        return $this;
-
-    }
-
     public function add($params = array())
     {
 


### PR DESCRIPTION
The constructor here is actually preventing the oDBOConnection dependency from getting instantiated on the oUser object. Removing it altogether fixed the issue with $this->get.